### PR TITLE
Update for friendly tuple support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,15 +15,15 @@ supercharged version of the original MicroPython driver. Its now more like a
 normal Python sequence and features slice support, ``repr`` and ``len`` support.
 
 Colors are now stored as ints by default rather than tuples. However, you can
-still use the tuple syntax to set values. For example, ``0x100000`` is equivalent
-to ``(0x10, 0, 0)``.
+still use the tuple syntax to set values. For example, ``0x100000`` is
+equivalent to ``(0x10, 0, 0)``. To make it easier to read and control each
+color component, readback values are expressed as tuples.
 
 .. note:: This API represents the brightness of the white pixel when present by
   setting the RGB channels to identical values. For example, full white is
   0xffffff but is actually (0, 0, 0, 0xff) in the tuple syntax. Setting a pixel
   value with an int will use the white pixel if the RGB channels are identical.
-  For full, independent, control of each color component use the tuple syntax
-  and ignore the readback value.
+  For full, independent, control of each color component use the tuple syntax.
 
 Dependencies
 =============
@@ -49,20 +49,20 @@ This example demonstrates the library with the single built-in NeoPixel on the
 
     pixels = neopixel.NeoPixel(board.NEOPIXEL, 1)
     pixels[0] = (10, 0, 0)
+    pixels.show()
 
 This example demonstrates the library with the ten built-in NeoPixels on the
-`Circuit Playground Express <https://www.adafruit.com/product/3333>`_. It turns off
-``auto_write`` so that all pixels are updated at once.
+`Circuit Playground Express <https://www.adafruit.com/product/3333>`_. It turns
+on ``auto_write`` so that all pixels are updated at once.
 
 .. code-block:: python
 
     import board
     import neopixel
 
-    pixels = neopixel.NeoPixel(board.NEOPIXEL, 10, auto_write=False)
+    pixels = neopixel.NeoPixel(board.NEOPIXEL, 10, auto_write=True)
     pixels[0] = (10, 0, 0)
     pixels[9] = (0, 10, 0)
-    pixels.show()
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -49,20 +49,21 @@ This example demonstrates the library with the single built-in NeoPixel on the
 
     pixels = neopixel.NeoPixel(board.NEOPIXEL, 1)
     pixels[0] = (10, 0, 0)
-    pixels.show()
 
 This example demonstrates the library with the ten built-in NeoPixels on the
 `Circuit Playground Express <https://www.adafruit.com/product/3333>`_. It turns
-on ``auto_write`` so that all pixels are updated at once.
+off ``auto_write`` so that all pixels are updated at once when the ``show``
+method is called.
 
 .. code-block:: python
 
     import board
     import neopixel
 
-    pixels = neopixel.NeoPixel(board.NEOPIXEL, 10, auto_write=True)
+    pixels = neopixel.NeoPixel(board.NEOPIXEL, 10, auto_write=False)
     pixels[0] = (10, 0, 0)
     pixels[9] = (0, 10, 0)
+    pixels.show()
 
 Contributing
 ============

--- a/neopixel.py
+++ b/neopixel.py
@@ -71,7 +71,7 @@ class NeoPixel:
             time.sleep(2)
     """
     ORDER = (1, 0, 2, 3)
-    def __init__(self, pin, n, bpp=3, brightness=1.0, auto_write=False):
+    def __init__(self, pin, n, bpp=3, brightness=1.0, auto_write=True):
         self.pin = digitalio.DigitalInOut(pin)
         self.pin.direction = digitalio.Direction.OUTPUT
         self.n = n

--- a/neopixel.py
+++ b/neopixel.py
@@ -71,7 +71,7 @@ class NeoPixel:
             time.sleep(2)
     """
     ORDER = (1, 0, 2, 3)
-    def __init__(self, pin, n, bpp=3, brightness=1.0, auto_write=True):
+    def __init__(self, pin, n, bpp=3, brightness=1.0, auto_write=False):
         self.pin = digitalio.DigitalInOut(pin)
         self.pin.direction = digitalio.Direction.OUTPUT
         self.n = n
@@ -91,7 +91,7 @@ class NeoPixel:
         self.pin.deinit()
 
     def __repr__(self):
-        return "[" + ", ".join(["0x%06x" % (x,) for x in self]) + "]"
+        return "[" + ", ".join([str(x) for x in self]) + "]"
 
     def _set_item(self, index, value):
         offset = index * self.bpp
@@ -142,14 +142,16 @@ class NeoPixel:
         if isinstance(index, slice):
             out = []
             for in_i in range(*index.indices(len(self.buf) // self.bpp)):
-                out.append(self[in_i])
+                out.append(tuple(self.buf[in_i * self.bpp + self.ORDER[i]]
+                           for i in range(self.bpp)))
             return out
         offset = index * self.bpp
         if self.bpp == 4:
             w = self.buf[offset + 3]
             if w != 0:
                 return w << 16 | w << 8 | w
-        return self.buf[offset + 1] << 16 | self.buf[offset] << 8 | self.buf[offset + 2]
+        return tuple(self.buf[offset + self.ORDER[i]]
+                     for i in range(self.bpp))
 
     def __len__(self):
         return len(self.buf) // self.bpp


### PR DESCRIPTION
This PR does several related things that fix backwards compatibility related problems in as "light touch" manner as possible (i.e. we retain all the awesome improvements you've made). :-) It fixes the issues highlighted in #7.

* Indexing and slicing a `NeoPixel` object returns colour values as RGB tuples. RGB tuples are what *every other* `neopixel` module on MicroPython returns. Consistency matters! ;-)
* I've also made sure `__repr__` uses RGB tuples to represent colours.
* I've set the default for `auto_write` to `False` so, once again, this version of the `neopixel` module works, by default, in the same way as all the other MicroPython based `neopixel` modules. Obviously, it's very easy to enable this feature when instantiating the object.
* I've made minor updates to the `README` to reflect these changes.

Discussion:

I notice you've implemented the update function as `show` and aliased `write`. I like how it's consistent with the micro:bit version of the `neopixel` module yet also backwards compatible. I believe this is a good thing (it's a more obvious name for such a function, especially if you're a beginner). This also suggests that you care about consistency and compatibility between implementations. Unfortunately, the awesome changes you've made (slicing, auto_write, yay!) also introduce other inconsistencies between different implementations of the module.

Ergo, this PR retains all the good stuff while also making this `neopixel` module __consistently__ consistent with all the other `neopixel` modules. :-)

It also means that the code examples in my book are no longer knackered. :-P

As always, comments, constructive criticism and ideas are most welcome!