### PR TITLE
Setup.py: switch `adafruit_neopixel` to `neopixel`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,5 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    py_modules=['adafruit_neopixel'],
+    py_modules=['neopixel'],
 )


### PR DESCRIPTION
PR for Related Issue: https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel/issues/31