### PR TITLE
 throw error if color tuple/pixel_order mismatch

### DIFF
--- a/neopixel.py
+++ b/neopixel.py
@@ -145,10 +145,7 @@ class NeoPixel:
                 g = 0
                 b = 0
         elif (len(value) == self.bpp) or ((len(value) == 3) and (self.bpp == 4)):
-            if len(value) == 3:
-                r, g, b = value[0:3]
-            else:
-                r, g, b, w = value
+            r, g, b, w = value if len(value) == 4 else value+(0,)
         else:
             raise ValueError("Color tuple size does not match pixel_order.")
 

--- a/neopixel.py
+++ b/neopixel.py
@@ -131,6 +131,8 @@ class NeoPixel:
         b = 0
         w = 0
         if isinstance(value, int):
+            if value>>24:
+                raise ValueError("only bits 0->23 valid for integer input")
             r = value >> 16
             g = (value >> 8) & 0xff
             b = value & 0xff
@@ -142,9 +144,9 @@ class NeoPixel:
                 r = 0
                 g = 0
                 b = 0
-        elif len(value) == self.bpp:
-            if self.bpp == 3:
-                r, g, b = value
+        elif (len(value) == self.bpp) or ((len(value) == 3) and (self.bpp == 4)):
+            if len(value) == 3:
+                r, g, b = value[0:3]
             else:
                 r, g, b, w = value
         else:

--- a/neopixel.py
+++ b/neopixel.py
@@ -147,6 +147,9 @@ class NeoPixel:
                 r, g, b = value
             else:
                 r, g, b, w = value
+        else:
+            raise ValueError("Color tuple size does not match pixel_order.")
+
         self.buf[offset + self.order[0]] = r
         self.buf[offset + self.order[1]] = g
         self.buf[offset + self.order[2]] = b


### PR DESCRIPTION
Is this what you had in mind to address #34 ?

```
Adafruit CircuitPython 4.0.0-alpha.2-84-gbd79c0c0d-dirty on 2018-10-28; Adafruit Metro M4 Express with samd51j19
>>>
>>> import board,neopixel
>>> pixels = neopixel.NeoPixel(board.NEOPIXEL, 1, pixel_order=neopixel.RGB)
>>> pixels[0] = (255,0,0)
>>> pixels[0] = (255,0,0,0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "neopixel.py", line 170, in __setitem__
  File "neopixel.py", line 151, in _set_item
ValueError: Color tuple size does not match pixel_order.
>>>
```
```
Adafruit CircuitPython 4.0.0-alpha.2-84-gbd79c0c0d-dirty on 2018-10-28; Adafruit Metro M4 Express with samd51j19
>>> import board,neopixel
>>> pixels = neopixel.NeoPixel(board.A2, 8, pixel_order=neopixel.RGBW)
>>> pixels = neopixel.NeoPixel(board.NEOPIXEL,1, pixel_order=neopixel.RGBW)
>>> pixels[0]=(255,0,0,0)
>>> pixels[0]=(255,0,0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "neopixel.py", line 170, in __setitem__
  File "neopixel.py", line 151, in _set_item
ValueError: Color tuple size does not match pixel_order.
>>> 
```