### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Adafruit CircuitPython NeoPixel
     :target: https://adafru.it/discord
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_NeoPixel.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_NeoPixel
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_NeoPixel.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_NeoPixel
     :alt: Build Status
 
 Higher level NeoPixel driver that presents the strip as a sequence. This is a


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.