### PR TITLE
add mock for testing without pi

### DIFF
--- a/examples/mock_example.py
+++ b/examples/mock_example.py
@@ -1,0 +1,19 @@
+import neopixel
+
+ORDER = neopixel.GRB
+num_pixels = 450 # total length of led strip
+
+try:
+    import board
+    PIXEL_GPIO = board.D18
+
+except NotImplementedError as n:
+    print('not implemented!! {}'.format(n))
+    PIXEL_GPIO = 0
+    mock = True
+
+pixels = neopixel.NeoPixel(PIXEL_GPIO, num_pixels, brightness=0.2, auto_write=False,
+                           pixel_order=ORDER, mock=mock)
+
+
+pixels.fill((255,50,255))

--- a/neopixel.py
+++ b/neopixel.py
@@ -92,9 +92,13 @@ class NeoPixel:
             pixels[::2] = [RED] * (len(pixels) // 2)
             time.sleep(2)
     """
-    def __init__(self, pin, n, *, bpp=3, brightness=1.0, auto_write=True, pixel_order=None):
-        self.pin = digitalio.DigitalInOut(pin)
-        self.pin.direction = digitalio.Direction.OUTPUT
+    def __init__(self, pin, n, *, bpp=3, brightness=1.0, auto_write=True, pixel_order=None, mock=False):
+        self.mock = mock
+        if not mock:
+            self.pin = digitalio.DigitalInOut(pin)
+            self.pin.direction = digitalio.Direction.OUTPUT
+        else:
+            self.pin = pin
         self.n = n
         if pixel_order is None:
             self.order = GRBW
@@ -113,8 +117,9 @@ class NeoPixel:
         """Blank out the NeoPixels and release the pin."""
         for i in range(len(self.buf)):
             self.buf[i] = 0
-        neopixel_write(self.pin, self.buf)
-        self.pin.deinit()
+        if not self.mock:
+            neopixel_write(self.pin, self.buf)
+            self.pin.deinit()
 
     def __enter__(self):
         return self
@@ -231,6 +236,8 @@ class NeoPixel:
 
         The colors may or may not be showing after this function returns because
         it may be done asynchronously."""
+        if self.mock:
+            return
         if self.brightness > 0.99:
             neopixel_write(self.pin, self.buf)
         else:


### PR DESCRIPTION
I ran into a situation where a lot of development had to occur without access to a raspberry. This should more or less take care of it , allowing one to write into the buffer and call pixels.show() without crashing . Example included for checking if board is present and if  not use mock , s.t. same code can run on laptop as on raspi 