### PR TITLE
Initialise self.pin before calling pypixelbuf

### DIFF
--- a/neopixel.py
+++ b/neopixel.py
@@ -127,13 +127,13 @@ class NeoPixel(_pixelbuf.PixelBuf):
             if isinstance(pixel_order, tuple):
                 order_list = [RGBW[order] for order in pixel_order]
                 pixel_order = "".join(order_list)
+        
+        self.pin = digitalio.DigitalInOut(pin)
+        self.pin.direction = digitalio.Direction.OUTPUT
 
         super().__init__(
             n, brightness=brightness, byteorder=pixel_order, auto_write=auto_write
         )
-
-        self.pin = digitalio.DigitalInOut(pin)
-        self.pin.direction = digitalio.Direction.OUTPUT
 
     def deinit(self):
         """Blank out the NeoPixels and release the pin."""

--- a/neopixel.py
+++ b/neopixel.py
@@ -127,7 +127,7 @@ class NeoPixel(_pixelbuf.PixelBuf):
             if isinstance(pixel_order, tuple):
                 order_list = [RGBW[order] for order in pixel_order]
                 pixel_order = "".join(order_list)
-        
+
         self.pin = digitalio.DigitalInOut(pin)
         self.pin.direction = digitalio.Direction.OUTPUT
 


### PR DESCRIPTION
This fixes #85 

Tested on STM32F411CE "blackpill" running CircuitPython 5.3.0, Trinket M0 and ItsyBitsy M4 both running 5.4.0 beta 0. All against pypixelbuf from bundle 5.x-200526. 