### PR TITLE
pixel_order is missing from the constructor param list

### DIFF
--- a/neopixel.py
+++ b/neopixel.py
@@ -70,7 +70,7 @@ class NeoPixel(_pixelbuf.PixelBuf):
       brightness
     :param bool auto_write: True if the neopixels should immediately change when set. If False,
       `show` must be called explicitly.
-    :param str: Set the pixel color channel order. GRBW is set by default.
+    :param str pixel_order: Set the pixel color channel order. GRBW is set by default.
 
     Example for Circuit Playground Express:
 


### PR DESCRIPTION
`pixel_order` seems to be missing. I assume this is how the docs should look...