### PR TITLE
Create hsv neopixel [DRAFT]

### DIFF
--- a/examples/neopixelhsv_simpletest.py
+++ b/examples/neopixelhsv_simpletest.py
@@ -1,0 +1,17 @@
+import time
+import board
+from neopixelhsv import NeoPixelHSV
+
+# On a Raspberry pi, use this instead, not all pins are supported
+pixel_pin = board.D18
+
+# The number of NeoPixels
+num_pixels = 10
+
+pixels = NeoPixelHSV(
+    pixel_pin, num_pixels, brightness=1, auto_write=True
+)
+
+for i in range(0, 360, 1):
+    pixels[9] = ((i, 100, 100))
+    time.sleep(0.01)

--- a/neopixelhsv.py
+++ b/neopixelhsv.py
@@ -1,0 +1,33 @@
+import colorsys
+import neopixel
+
+class NeoPixelHSV(neopixel.NeoPixel):
+    """HSV:
+    Hue: 0-360
+    Saturation: 0-100
+    Value: 0-100
+    """
+    def __init__(
+        self, pin, n, *, bpp=3, brightness=1.0, auto_write=True
+    ):
+        pixel_order = neopixel.RGB if bpp == 3 else neopixel.RGBW
+        super().__init__(
+            pin, n, bpp=bpp, brightness=brightness, auto_write=auto_write, pixel_order=pixel_order,
+        )
+
+    def fill(self, color):
+        super().fill(self.__hsv_to_rgb(color))
+            
+    def __setitem__(self, index, color):
+        super().__setitem__(index, self.__hsv_to_rgb(color))
+        
+    def __getitem__(self, index):
+        return(self.__rgb_to_hsv(super().__getitem__(index)))
+        
+    def __hsv_to_rgb(self, color):
+        rgb_color = colorsys.hsv_to_rgb(color[0]/360, color[1]/100, color[2]/100)
+        return [int(x * 255) for x in rgb_color]
+    
+    def __rgb_to_hsv(self, color):
+        hsv_color = colorsys.rgb_to_hsv(color[0]/255, color[1]/255, color[2]/255)
+        return (int(hsv_color[0]*360), int(hsv_color[1]*100), int(hsv_color[2]*100))


### PR DESCRIPTION
Add a version of neopixel version that uses HSV instead of RGB/GRB.

**NOTE:** This is just an initial proposal. To know if this is something could be interesting to have. See https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel/issues/107