### PR TITLE
Update to use adafruit_pixelbuf.

### DIFF
--- a/neopixel.py
+++ b/neopixel.py
@@ -19,9 +19,12 @@ import digitalio
 from neopixel_write import neopixel_write
 
 try:
-    import _pixelbuf
+    import adafruit_pixelbuf
 except ImportError:
-    import adafruit_pypixelbuf as _pixelbuf
+    try:
+        import _pixelbuf as adafruit_pixelbuf
+    except ImportError:
+        import adafruit_pypixelbuf as adafruit_pixelbuf
 
 
 __version__ = "0.0.0-auto.0"
@@ -39,7 +42,7 @@ GRBW = "GRBW"
 """Green Red Blue White"""
 
 
-class NeoPixel(_pixelbuf.PixelBuf):
+class NeoPixel(adafruit_pixelbuf.PixelBuf):
     """
     A sequence of neopixels.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
-adafruit-circuitpython-pypixelbuf>=2.0.0
+adafruit-circuitpython-pixelbuf

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     # Author details
     author="Adafruit Industries & Damien P. George",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka", "adafruit-circuitpython-pypixelbuf>=2.0.0"],
+    install_requires=["Adafruit-Blinka", "adafruit-circuitpython-pixelbuf"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
https://github.com/adafruit/circuitpython/pull/5010 renames `_pixelbuf` to `adafruit_pixelbuf`.

Maintains backwards compatibility until such time that we are ready to remove it.