### PR TITLE
Allow NEOPIXEL_POWER* init outside of NeoPixel lib

### DIFF
--- a/neopixel.py
+++ b/neopixel.py
@@ -120,8 +120,11 @@ class NeoPixel(adafruit_pixelbuf.PixelBuf):
             if not power:
                 power = getattr(board, "NEOPIXEL_POWER", None)
             if power:
-                self._power = digitalio.DigitalInOut(power)
-                self._power.switch_to_output(value=polarity)
+                try:
+                    self._power = digitalio.DigitalInOut(power)
+                    self._power.switch_to_output(value=polarity)
+                except ValueError:
+                    pass
 
         super().__init__(
             n, brightness=brightness, byteorder=pixel_order, auto_write=auto_write


### PR DESCRIPTION
Ignore exception when trying to set up `NEOPIXEL_POWER`* pin, since user may have set that up already for controlling power independent of this library.

Based on comments starting here:
https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel/pull/111#issuecomment-896489059

Tested on `Adafruit CircuitPython 7.0.0-alpha.5-187-g1e53cf40a on 2021-08-11; Adafruit MagTag with ESP32S2`
```py
import board, digitalio, neopixel

# NeoPixels & light sensor
aux_power_io = digitalio.DigitalInOut(board.NEOPIXEL_POWER_INVERTED)
aux_power_io.direction = digitalio.Direction.OUTPUT
aux_power_io.value = False  # active low

status_light = neopixel.NeoPixel(board.NEOPIXEL, 4, brightness=0.05, pixel_order=neopixel.GRB)

status_light[1] = (255, 0, 255)
aux_power_io.value = True  # turn OFF NeoPixel power
status_light[2] = (0, 255, 0)  # no change after this statement (as expected)

# an interesting quirk:
aux_power_io.value = False  # no change after this statement
status_light[1] = (255, 0, 255)  # both NeoPixels turn on after this statement
# individual NeoPixel status is retained when power is disabled,
# but when power is re-enabled, it takes a new write to display all
```