### PR TITLE
Update version string, add setuptools-scm as build system requirement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,9 @@ jobs:
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upfor file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
+            sed -i -e "s/0.0.0-auto.0/0.0.0+auto.0/" $file;
+        done;load-artifact@v2
       with:
         name: bundles
         path: ${{ github.workspace }}/bundles/
@@ -71,7 +73,7 @@ jobs:
       run: |
         pip install --upgrade build twine
         for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
-            sed -i -e "s/0.0.0-auto.0/1.2.3/" $file;
+            sed -i -e "s/0.0.0+auto.0/1.2.3/" $file;
         done;
         python -m build
         twine check dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,7 @@ jobs:
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles
-      uses: actions/upfor file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
-            sed -i -e "s/0.0.0-auto.0/0.0.0+auto.0/" $file;
-        done;load-artifact@v2
+      uses: actions/upload-artifact@v2
       with:
         name: bundles
         path: ${{ github.workspace }}/bundles/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
         for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
-            sed -i -e "s/0.0.0-auto.0/${{github.event.release.tag_name}}/" $file;
+            sed -i -e "s/0.0.0+auto.0/${{github.event.release.tag_name}}/" $file;
         done;
         python -m build
         twine upload dist/*

--- a/neopixel.py
+++ b/neopixel.py
@@ -28,7 +28,7 @@ except ImportError:
     pass
 
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel.git"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@
 requires = [
     "setuptools",
     "wheel",
+    "setuptools-scm",
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
 [project]
 name = "adafruit-circuitpython-neopixel"
 description = "CircuitPython library for NeoPixel LEDs."
-version = "0.0.0-auto.0"
+version = "0.0.0+auto.0"
 readme = "README.rst"
 authors = [
     {name = "Adafruit Industries", email = "circuitpython@adafruit.com"}


### PR DESCRIPTION
- Version string update per updates to all other bundle libraries
- `setuptools-scm` is needed for `git` tracked files to be added to the build, which allows for the dynamic build requirements files to actually work