### PR TITLE
added setup instructions for sudo-less RPi usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,11 +111,11 @@ need to be specified as it is computed from the supplied ``pixel_order``.
     pixel[0] = (30, 0, 20, 10)
 
 Setup for sudo-less usage on Raspberry Pi boards
-=============
+================================================
 1. Enable both SPI and Serial port hardware (Serial interface). Do it by ``raspi-config`` tool or manually by adding
 
    ::
-   
+
       dtparam=spi=on
       enable_uart=1
 

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,7 @@ Setup for sudo-less usage on Raspberry Pi boards
 1. Enable both SPI and Serial port hardware (Serial interface). Do it by ``raspi-config`` tool or manually by adding
 
    ::
+   
       dtparam=spi=on
       enable_uart=1
 
@@ -129,7 +130,7 @@ When initializing the ``NeoPixel`` object **always** do it with ``board.D10`` (G
 
     import board
     import neopixel
-    
+
     DATA_PIN = board.D10
     pixel = neopixel.NeoPixel(DATA_PIN, ...)
 

--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,32 @@ need to be specified as it is computed from the supplied ``pixel_order``.
     pixel = neopixel.NeoPixel(board.D0, 1, pixel_order=neopixel.RGBW)
     pixel[0] = (30, 0, 20, 10)
 
+Setup for sudo-less usage on Raspberry Pi boards
+=============
+1. Enable both SPI and Serial port hardware (Serial interface). Do it by ``raspi-config`` tool or manually by adding
+
+   ::
+   
+      dtparam=spi=on
+      enable_uart=1
+
+   to the ``/boot/config.txt``
+
+2. Reboot the Pi to apply the changes - the hardware setup takes place during boot. 
+3. Connect LED's DIN to ``GPIO10`` (physical pin 19)
+
+When initializing the ``NeoPixel`` object **always** do it with ``board.D10`` (GPIO10)
+
+.. code-block:: python
+
+    import board
+    import neopixel
+    
+    DATA_PIN = board.D10
+    pixel = neopixel.NeoPixel(DATA_PIN, ...)
+
+Now you can execute the code using ``python`` without ``sudo``
+
 Documentation
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -115,13 +115,12 @@ Setup for sudo-less usage on Raspberry Pi boards
 1. Enable both SPI and Serial port hardware (Serial interface). Do it by ``raspi-config`` tool or manually by adding
 
    ::
-   
       dtparam=spi=on
       enable_uart=1
 
    to the ``/boot/config.txt``
 
-2. Reboot the Pi to apply the changes - the hardware setup takes place during boot. 
+2. Reboot the Pi to apply the changes - the hardware setup takes place during boot.
 3. Connect LED's DIN to ``GPIO10`` (physical pin 19)
 
 When initializing the ``NeoPixel`` object **always** do it with ``board.D10`` (GPIO10)


### PR DESCRIPTION
Resolved the problem when using the SPI MOSI (GPIO 10) would result in unexpected behaviour when sending signals for a long periods. Turns out that Serial interface/ Serial port hardware has to be enabled otherwise the communication on SPI was being cut after few seconds. resolves #104 resolves #72 resolves #58 