### PR TITLE
Update README.rst to add dependancy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ Dependencies
 This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
+* `adafruit_pixelbuf library <https://github.com/adafruit/Adafruit_CircuitPython_Pixelbuf>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Dependencies
 This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
-* `adafruit_pixelbuf library <https://github.com/adafruit/Adafruit_CircuitPython_Pixelbuf>`_
+* `Adafruit CircuitPython Pixelbuf library <https://github.com/adafruit/Adafruit_CircuitPython_Pixelbuf>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading


### PR DESCRIPTION
Requires adafruit_pixelbuf library. 

Line 20 of the neopixel.py code is 
`import adafruit_pixelbuf`
so must have.